### PR TITLE
Add methods for using netty 4.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <jackson.version>2.4.5</jackson.version>
         <swagger.version>1.5.16</swagger.version>
-        <netty.version>4.0.33.Final</netty.version>
+        <netty.version>4.1.17.Final</netty.version>
         <air.version>0.117</air.version>
     </properties>
 

--- a/src/main/java/org/rakam/server/http/HttpServerHandler.java
+++ b/src/main/java/org/rakam/server/http/HttpServerHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -64,7 +64,7 @@ public class HttpServerHandler
     public void channelRead(ChannelHandlerContext ctx, Object msg)
             throws Exception
     {
-        if (HttpHeaders.is100ContinueExpected(request)) {
+        if ( HttpUtil.is100ContinueExpected(request)) {
             ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
         }
 

--- a/src/main/java/org/rakam/server/http/RakamHttpRequest.java
+++ b/src/main/java/org/rakam/server/http/RakamHttpRequest.java
@@ -45,6 +45,7 @@ public class RakamHttpRequest
     private HttpRequest request;
     private FullHttpResponse response;
 
+
     @Override
     public boolean equals(Object o)
     {
@@ -84,6 +85,10 @@ public class RakamHttpRequest
     }
 
     @Override
+    public HttpMethod method(){ return request.getMethod(); }
+
+
+    @Override
     public HttpRequest setMethod(HttpMethod method)
     {
         return request.setMethod(method);
@@ -96,6 +101,10 @@ public class RakamHttpRequest
     }
 
     @Override
+    public String uri(){ return request.getUri();}
+
+
+    @Override
     public HttpRequest setUri(String uri)
     {
         return request.setUri(uri);
@@ -106,6 +115,10 @@ public class RakamHttpRequest
     {
         return request.getProtocolVersion();
     }
+
+    @Override
+    public HttpVersion protocolVersion(){ return request.getProtocolVersion(); }
+
 
     @Override
     public io.netty.handler.codec.http.HttpRequest setProtocolVersion(HttpVersion version)
@@ -125,10 +138,11 @@ public class RakamHttpRequest
     }
 
     @Override
-    public DecoderResult getDecoderResult()
-    {
-        return request.getDecoderResult();
-    }
+    public DecoderResult getDecoderResult() { return request.getDecoderResult(); }
+
+    @Override
+    public DecoderResult decoderResult(){return request.getDecoderResult();}
+
 
     protected Consumer<InputStream> getBodyHandler()
     {


### PR DESCRIPTION
Hey, I have a project I am working on where I have another dependency that uses netty 4.1.x.  When I run it I get runtime errors that seem to be because netty-rest is uses netty-4.0.x.

It looks like I just needed to add the methods in this PR to make it work with netty-4.1.x.  I have not done much developing in java so I am sure this isn't the right way to do it, but if you are willing to give me some guidance and think this might be worthwhile, I am willing to do the work.

I don't expect this is a mergable PR, so please reject it at your convenience.

Thanks!